### PR TITLE
Recorder test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ set (CMAKE_CXX_STANDARD 11)
 project(Recorder)
 
 add_library(recorder SHARED recorder.hpp recorder.cpp)
-
 add_executable(test test.cpp)
 target_link_libraries(test recorder)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,18 @@ set (CMAKE_CXX_STANDARD 11)
 project(Recorder)
 
 add_library(recorder SHARED recorder.hpp recorder.cpp)
+
 add_executable(test test.cpp)
 target_link_libraries(test recorder)
 
 install(TARGETS test DESTINATION bin)
+file(GLOB HEADERS *.hpp)
+install(FILES ${HEADERS} DESTINATION include)
+install(TARGETS recorder
+	PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE 
+				GROUP_READ GROUP_WRITE GROUP_EXECUTE 
+				WORLD_READ WORLD_EXECUTE
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib
+	RUNTIME DESTINATION bin
+	)


### PR DESCRIPTION
@jgillis, this PR adjusts CMakeLists so that the install folder contains distinct folders for bin, lib, and include. That way, I can then easily set the links with Simbody and OpenSim. Thanks.