### PR TITLE
License Apache 2.0

### DIFF
--- a/recorder.cpp
+++ b/recorder.cpp
@@ -1,4 +1,21 @@
-
+/*
+ *      Recorder -- A package for Algorithmic Differentiation with CasADi
+ *
+ *      Copyright (C) 2019 The Authors
+ *      Author: Joris Gillis
+ *      Contributor: Antoine Falisse
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License"); you
+ *      may not use this file except in compliance with the License. You may
+ *      obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *      implied. See the License for the specific language governing
+ *      permissions and limitations under the License.
+ */
 
 #include <iostream>
 #include <sstream>
@@ -11,7 +28,6 @@
 
 static int counter_asserts = 0;
 
-
 Recorder::Recorder(const Recorder& r) {
   value_ = r.value_;
   if (r.is_symbol()) {
@@ -23,11 +39,12 @@ Recorder::Recorder(const Recorder& r) {
 }
 
 Recorder::~Recorder() {
-       if(id_ == 0) std::cout << "goodbyw" << id_ << ":" << value_ << std::endl;
+       if(id_ == 0) std::cout << "goodbye" << id_ << ":" << value_ << std::endl;
 }
 
 Recorder::Recorder() : id_(-1), value_(3.14) {}
 Recorder::Recorder(double value) : id_(-1), value_(value) {}
+
 void Recorder::operator<<=(double value) {
   if (is_symbol()) throw std::runtime_error("Needs to be symbolic");
   id_ = get_id();
@@ -50,6 +67,7 @@ Recorder& Recorder::operator = ( const Recorder& r) {
   }
   return *this;
 }
+
 void Recorder::operator>>=(double& value) {
   if (!is_symbol()) throw std::runtime_error("Needs to be symbolic");
   stream() << "if ~nom" << std::endl;
@@ -91,15 +109,12 @@ bool operator!=(const Recorder& lhs, const Recorder& rhs) {
 bool operator==(const Recorder& lhs, const Recorder& rhs) {
   return static_cast<bool>(Recorder::from_binary(lhs, rhs, lhs.value_ == rhs.value_, "eq"));
 }
-
 Recorder operator-(const Recorder& arg) {
     return Recorder::from_unary(arg, -arg.value_, "uminus");
 }
-
 Recorder pow( const Recorder&lhs, const Recorder& rhs) {
     return Recorder::from_binary(lhs, rhs, pow(lhs.value_,rhs.value_), "power");
 }
-
 Recorder fmax ( const Recorder&lhs, const Recorder& rhs) {
 	return Recorder::from_binary(lhs, rhs, fmax(lhs.value_,rhs.value_), "max");
 }
@@ -109,7 +124,6 @@ Recorder fmin ( const Recorder&lhs, const Recorder& rhs) {
 Recorder atan2 ( const Recorder&lhs, const Recorder& rhs) {
 	return Recorder::from_binary(lhs, rhs, atan2(lhs.value_,rhs.value_), "atan2");
 }
-
 Recorder exp(const Recorder& arg) {
     return Recorder::from_unary(arg, exp(arg.value_), "exp");
 }
@@ -137,7 +151,6 @@ Recorder acos(const Recorder& arg) {
 Recorder atan(const Recorder& arg) {
     return Recorder::from_unary(arg, atan(arg.value_), "atan");
 }
-
 Recorder log10(const Recorder& arg) {
     return Recorder::from_unary(arg, log10(arg.value_), "log10");
 }
@@ -181,6 +194,7 @@ Recorder::operator bool() const {
     }
     return ret;
 }
+
 std::ostream& operator<<(std::ostream &stream, const Recorder& obj) {
   obj.disp(stream);
   return stream;
@@ -196,6 +210,7 @@ void Recorder::stop_recording() {
     stream() << "a = vertcat(a{:});" << std::endl;
   }
 }
+
 void Recorder::disp(std::ostream &stream) const {
   if (is_symbol()) {
     stream << "[#" << id_ << "|" << value_ << "]";
@@ -203,13 +218,16 @@ void Recorder::disp(std::ostream &stream) const {
     stream << "(" << value_ << ")";
   }
 }
+
 int Recorder::get_id() {
   counter++;
   return counter;
 }
+
 bool Recorder::is_symbol() const {
   return id_>=0;
 }
+
 std::string Recorder::repr() const {
   if (is_symbol()) {
     return "a" + std::to_string(id_);
@@ -222,7 +240,7 @@ std::string Recorder::repr() const {
 }
 
 bool is_suspicious(double v) {
-  return (v>0 && v <1e-200) || (v<0 && v >-1e-200); 
+  return (v>0 && v <1e-200) || (v<0 && v >-1e-200);
 }
 
 Recorder Recorder::from_binary(const Recorder& lhs, const Recorder& rhs, double res, const std::string& op) {
@@ -240,6 +258,7 @@ Recorder Recorder::from_binary(const Recorder& lhs, const Recorder& rhs, double 
     return Recorder(res);
   }
 }
+
 Recorder Recorder::from_unary(const Recorder& arg, double res, const std::string& op) {
   if (arg.is_symbol()) {
     int id = get_id();
@@ -256,7 +275,6 @@ Recorder Recorder::from_unary(const Recorder& arg, double res, const std::string
   }
 }
 
-
 class StreamWrapper {
 public:
     StreamWrapper() {
@@ -270,10 +288,10 @@ public:
 };
 static StreamWrapper stream_wrapper{};
 
-
 std::ofstream& Recorder::stream() {
   return *stream_wrapper.stream;
 };
+
 Recorder::Recorder(double value, int id) {
   id_ = id;
   value_ = value;

--- a/recorder.hpp
+++ b/recorder.hpp
@@ -1,24 +1,24 @@
 #ifndef Recorder_H_
 #define Recorder_H_
 
-/* ---------------------------------------------------------------------------*
- *      Recorder -- A package for Automatic Differentiation                   *
- *                                                                            *
- *      Copyright (C) 2018 The Authors                                        *
- *      Author: Joris Gillis                                                  *
- *      Contributor: Antoine Falisse                                          *
- *                                                                            *
- *      Licensed under the Apache License, Version 2.0 (the "License"); you   *
- *      may not use this file except in compliance with the License. You may  *
- *      obtain a copy of the License at                                       *
- *      http://www.apache.org/licenses/LICENSE-2.0.                           *
- *                                                                            *
- *      Unless required by applicable law or agreed to in writing, software   *
- *      distributed under the License is distributed on an "AS IS" BASIS,     *
- *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       *
- *      implied. See the License for the specific language governing          *
- *      permissions and limitations under the License.                        *
- * --------------------------------------------------------------------------*/
+/*
+ *      Recorder -- A package for Algorithmic Differentiation with CasADi
+ *
+ *      Copyright (C) 2019 The Authors
+ *      Author: Joris Gillis
+ *      Contributor: Antoine Falisse
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License"); you
+ *      may not use this file except in compliance with the License. You may
+ *      obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *      implied. See the License for the specific language governing
+ *      permissions and limitations under the License.
+ */
 
 #include <iostream>
 
@@ -49,7 +49,7 @@ public:
   /* IO friends */
   friend DLL_EXPORT std::istream& operator >> (std::istream& is, const Recorder& a);
 
-  /* Operation + Assignment */
+  /* Operation and assignment */
   inline Recorder& operator += ( double value ) { return operator+=(Recorder(value)); }
   inline Recorder& operator += ( const Recorder& value) { return operator=(*this+value); }
   inline Recorder& operator -= ( double value ) { return operator-=(Recorder(value)); }
@@ -59,25 +59,25 @@ public:
   inline Recorder& operator /= ( double value)  { return operator/=(Recorder(value)); }
   inline Recorder& operator /= ( const Recorder& value) { return operator=(*this/value); }
 
-  /* Comparison (friends) */
-  friend     bool DLL_EXPORT operator != ( const Recorder&, const Recorder& );
-  friend     bool DLL_EXPORT operator == ( const Recorder&, const Recorder& );
-  friend     bool DLL_EXPORT operator <= ( const Recorder&, const Recorder& );
-  friend     bool DLL_EXPORT operator >= ( const Recorder&, const Recorder& );
-  friend     bool DLL_EXPORT operator >  ( const Recorder&, const Recorder& );
-  friend     bool DLL_EXPORT operator <  ( const Recorder&, const Recorder& );
-  inline friend    bool operator != (double lhs, const Recorder& rhs) { return Recorder(lhs)!=rhs; }
-  inline friend    bool operator == ( double lhs, const Recorder& rhs) { return Recorder(lhs)==rhs; }
-  inline friend    bool operator <= ( double lhs, const Recorder& rhs) { return Recorder(lhs)<=rhs; }
-  inline friend    bool operator >= ( double lhs, const Recorder& rhs) { return Recorder(lhs)>=rhs; }
-  inline friend    bool operator >  ( double lhs, const Recorder& rhs) { return Recorder(lhs)>rhs; }
-  inline friend    bool operator <  ( double lhs, const Recorder& rhs) { return Recorder(lhs)<rhs; }
+  /* Comparison */
+  friend bool DLL_EXPORT operator != ( const Recorder&, const Recorder& );
+  friend bool DLL_EXPORT operator == ( const Recorder&, const Recorder& );
+  friend bool DLL_EXPORT operator <= ( const Recorder&, const Recorder& );
+  friend bool DLL_EXPORT operator >= ( const Recorder&, const Recorder& );
+  friend bool DLL_EXPORT operator >  ( const Recorder&, const Recorder& );
+  friend bool DLL_EXPORT operator <  ( const Recorder&, const Recorder& );
+  inline friend bool operator != (double lhs, const Recorder& rhs) { return Recorder(lhs)!=rhs; }
+  inline friend bool operator == ( double lhs, const Recorder& rhs) { return Recorder(lhs)==rhs; }
+  inline friend bool operator <= ( double lhs, const Recorder& rhs) { return Recorder(lhs)<=rhs; }
+  inline friend bool operator >= ( double lhs, const Recorder& rhs) { return Recorder(lhs)>=rhs; }
+  inline friend bool operator >  ( double lhs, const Recorder& rhs) { return Recorder(lhs)>rhs; }
+  inline friend bool operator <  ( double lhs, const Recorder& rhs) { return Recorder(lhs)<rhs; }
 
-  /* sign operators (friends) */
+  /* Sign operators */
   inline friend Recorder operator + ( const Recorder& x ) { return x; }
   friend Recorder DLL_EXPORT  operator - ( const Recorder& x );
 
-  /* binary operators (friends) */
+  /* Binary operators */
   friend Recorder DLL_EXPORT operator + ( const Recorder&, const Recorder& );
   inline friend Recorder operator + ( double lhs, const Recorder& rhs) { return Recorder(lhs)+rhs; }
   inline friend Recorder operator + ( const Recorder& lhs, double rhs)  { return lhs+Recorder(rhs); }
@@ -91,7 +91,7 @@ public:
   friend DLL_EXPORT Recorder operator / ( const Recorder&, const Recorder& );
   friend Recorder operator / ( double lhs, const Recorder& rhs )  { return Recorder(lhs)/rhs; }
 
-  /* unary operators (friends) */
+  /* Unary operators */
   friend Recorder DLL_EXPORT exp  ( const Recorder& );
   friend Recorder DLL_EXPORT log  ( const Recorder& );
   friend Recorder DLL_EXPORT sqrt ( const Recorder& );
@@ -102,11 +102,7 @@ public:
   friend Recorder DLL_EXPORT acos ( const Recorder& );
   friend Recorder DLL_EXPORT atan ( const Recorder& );
 
-  /* special operators (friends) */
-  inline friend Recorder    pow   ( const Recorder& lhs, double rhs) { return pow(lhs, Recorder(rhs)); }
-  friend DLL_EXPORT Recorder    log10 ( const Recorder& );
-
-  /* Additional ANSI C standard Math functions */
+  /* Additional functions */
   friend Recorder DLL_EXPORT sinh  ( const Recorder& );
   friend Recorder DLL_EXPORT cosh  ( const Recorder& );
   friend Recorder DLL_EXPORT tanh  ( const Recorder& );
@@ -124,14 +120,12 @@ public:
   inline friend Recorder fmin ( double lhs, const Recorder& rhs) { return fmin(Recorder(lhs), rhs); }
   inline friend Recorder fmin ( const Recorder& lhs, double rhs) { return fmin(lhs, Recorder(rhs)); }
 
-  //friend Recorder ldexp ( const Recorder&, int );
-  //friend Recorder frexp ( const Recorder&, int* );
-  /* special operators (friends) */
-  friend Recorder DLL_EXPORT  atan2 ( const Recorder&, const Recorder& );
-  friend Recorder DLL_EXPORT pow   ( const Recorder&, const Recorder& );
-  inline friend Recorder pow   ( double lhs, const Recorder& rhs) { return pow(Recorder(lhs), rhs); }
-  /* User defined version of logarithm to test extend_quad macro */
-  //friend Recorder myquad( const Recorder& );
+  /* Special operators */
+  friend Recorder DLL_EXPORT atan2 ( const Recorder&, const Recorder& );
+  friend DLL_EXPORT Recorder log10 ( const Recorder& );
+  friend Recorder DLL_EXPORT pow ( const Recorder&, const Recorder& );
+  inline friend Recorder pow ( double lhs, const Recorder& rhs) { return pow(Recorder(lhs), rhs); }
+  inline friend Recorder pow ( const Recorder& lhs, double rhs) { return pow(lhs, Recorder(rhs)); }
 
 protected:
   void disp(std::ostream &stream) const;
@@ -152,4 +146,4 @@ protected:
   static int counter_bool;
 };
 
-#endif
+#endif // Recorder_H_

--- a/recorder.hpp
+++ b/recorder.hpp
@@ -1,6 +1,24 @@
 #ifndef Recorder_H_
 #define Recorder_H_
 
+/* ---------------------------------------------------------------------------*
+ *      Recorder -- A package for Automatic Differentiation                   *
+ *                                                                            *
+ *      Copyright (C) 2018 The Authors                                        *
+ *      Author: Joris Gillis                                                  *
+ *      Contributor: Antoine Falisse                                          *
+ *                                                                            *
+ *      Licensed under the Apache License, Version 2.0 (the "License"); you   *
+ *      may not use this file except in compliance with the License. You may  *
+ *      obtain a copy of the License at                                       *
+ *      http://www.apache.org/licenses/LICENSE-2.0.                           *
+ *                                                                            *
+ *      Unless required by applicable law or agreed to in writing, software   *
+ *      distributed under the License is distributed on an "AS IS" BASIS,     *
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or       *
+ *      implied. See the License for the specific language governing          *
+ *      permissions and limitations under the License.                        *
+ * --------------------------------------------------------------------------*/
 
 #include <iostream>
 
@@ -9,7 +27,6 @@
 #else
 #define DLL_EXPORT
 #endif // defined _WIN32
-
 
 class DLL_EXPORT Recorder {
 public:
@@ -22,16 +39,16 @@ public:
   Recorder(const Recorder& r);
   friend DLL_EXPORT std::ostream& operator<<(std::ostream &stream, const Recorder& obj);
   static void stop_recording();
-  
+
   /* Assignments */
   double getValue() const;
   inline double value() const {return getValue();}
   inline Recorder& operator = ( double arg) { return operator=(Recorder(arg)); }
   Recorder& operator = ( const Recorder& );
-  
+
   /* IO friends */
   friend DLL_EXPORT std::istream& operator >> (std::istream& is, const Recorder& a);
-	
+
   /* Operation + Assignment */
   inline Recorder& operator += ( double value ) { return operator+=(Recorder(value)); }
   inline Recorder& operator += ( const Recorder& value) { return operator=(*this+value); }
@@ -41,7 +58,7 @@ public:
   inline Recorder& operator *= ( const Recorder& value) { return operator=(*this*value); }
   inline Recorder& operator /= ( double value)  { return operator/=(Recorder(value)); }
   inline Recorder& operator /= ( const Recorder& value) { return operator=(*this/value); }
-  
+
   /* Comparison (friends) */
   friend     bool DLL_EXPORT operator != ( const Recorder&, const Recorder& );
   friend     bool DLL_EXPORT operator == ( const Recorder&, const Recorder& );
@@ -55,11 +72,11 @@ public:
   inline friend    bool operator >= ( double lhs, const Recorder& rhs) { return Recorder(lhs)>=rhs; }
   inline friend    bool operator >  ( double lhs, const Recorder& rhs) { return Recorder(lhs)>rhs; }
   inline friend    bool operator <  ( double lhs, const Recorder& rhs) { return Recorder(lhs)<rhs; }
-	
+
   /* sign operators (friends) */
   inline friend Recorder operator + ( const Recorder& x ) { return x; }
   friend Recorder DLL_EXPORT  operator - ( const Recorder& x );
-  
+
   /* binary operators (friends) */
   friend Recorder DLL_EXPORT operator + ( const Recorder&, const Recorder& );
   inline friend Recorder operator + ( double lhs, const Recorder& rhs) { return Recorder(lhs)+rhs; }
@@ -73,7 +90,7 @@ public:
   inline friend Recorder operator / ( const Recorder& lhs, double rhs) { return lhs/Recorder(rhs); }
   friend DLL_EXPORT Recorder operator / ( const Recorder&, const Recorder& );
   friend Recorder operator / ( double lhs, const Recorder& rhs )  { return Recorder(lhs)/rhs; }
-	
+
   /* unary operators (friends) */
   friend Recorder DLL_EXPORT exp  ( const Recorder& );
   friend Recorder DLL_EXPORT log  ( const Recorder& );
@@ -84,13 +101,12 @@ public:
   friend Recorder DLL_EXPORT asin ( const Recorder& );
   friend Recorder DLL_EXPORT acos ( const Recorder& );
   friend Recorder DLL_EXPORT atan ( const Recorder& );
-	
+
   /* special operators (friends) */
-  /* no internal use of condassign: */
   inline friend Recorder    pow   ( const Recorder& lhs, double rhs) { return pow(lhs, Recorder(rhs)); }
   friend DLL_EXPORT Recorder    log10 ( const Recorder& );
 
-  /* Additional ANSI C standard Math functions Added by DWJ on 8/6/90 */
+  /* Additional ANSI C standard Math functions */
   friend Recorder DLL_EXPORT sinh  ( const Recorder& );
   friend Recorder DLL_EXPORT cosh  ( const Recorder& );
   friend Recorder DLL_EXPORT tanh  ( const Recorder& );
@@ -112,14 +128,11 @@ public:
   //friend Recorder frexp ( const Recorder&, int* );
   /* special operators (friends) */
   friend Recorder DLL_EXPORT  atan2 ( const Recorder&, const Recorder& );
-  /* uses condassign internally */
   friend Recorder DLL_EXPORT pow   ( const Recorder&, const Recorder& );
   inline friend Recorder pow   ( double lhs, const Recorder& rhs) { return pow(Recorder(lhs), rhs); }
   /* User defined version of logarithm to test extend_quad macro */
   //friend Recorder myquad( const Recorder& );
-	
-  
-   
+
 protected:
   void disp(std::ostream &stream) const;
   static int get_id();


### PR DESCRIPTION
@jgillis, I am working on trying to make my pipeline for generating simulations with OpenSim/Simbody while exploiting AD with Recorder/CasADi easily usable. I think that by adding a license to Recorder, I could then simply copy the Recorder code into Simbody, which would simplify building the pipeline and limit the number of dependencies. If I'm right, Apache 2.0 is a quite permissive license (the same as the one used in OpenSim) so that would be quite ideal but it is up to you of course. Let me know what you think. Thanks in advance.

Ps: I am planning to share the code when the paper comparing AD with FD gets accepted.