### PR TITLE
fabs should be abs in matlab

### DIFF
--- a/recorder.cpp
+++ b/recorder.cpp
@@ -176,7 +176,7 @@ Recorder erf(const Recorder& arg) {
     return Recorder::from_unary(arg, erf(arg.value_), "erf");
 }
 Recorder fabs(const Recorder& arg) {
-    return Recorder::from_unary(arg, fabs(arg.value_), "fabs");
+    return Recorder::from_unary(arg, fabs(arg.value_), "abs");
 }
 Recorder ceil(const Recorder& arg) {
     return Recorder::from_unary(arg, ceil(arg.value_), "ceil");


### PR DESCRIPTION
Hi @jgillis, I think I spotted a small bug: MATLAB uses `abs` rather than `fabs` so Recorder should output `abs` rather than `fabs`. Does that make sense for you? Thanks.